### PR TITLE
Armed/Unarmed condition backwards

### DIFF
--- a/src/IconChooser.tsx
+++ b/src/IconChooser.tsx
@@ -15,7 +15,7 @@ class IconCaption extends Component<CaptionProps> {
     override render() {
         let icon = this.props.icon;
 
-        let armed: JSX.Element = icon.armed ? <>, unarmed</> : <></>;
+        let armed: JSX.Element = icon.armed ? <></> : <>, unarmed</>;
         let variant: JSX.Element = icon.variant ? <i> ({capitalize(icon.variant)})</i> : <></>;
 
         return (


### PR DESCRIPTION
Line 18 - was listing all armed icons as unarmed in the UI